### PR TITLE
feat: Implement hybrid plasticity components and integrate with SNNDT

### DIFF
--- a/novel_phases/phase-2/custom_lif.py
+++ b/novel_phases/phase-2/custom_lif.py
@@ -1,0 +1,171 @@
+import torch
+import torch.nn as nn
+from norse.torch import LIFCell
+from norse.torch.functional.lif import LIFParameters
+from typing import Optional, Tuple, NamedTuple
+
+
+class CustomLIFCellState(NamedTuple):
+    v: torch.Tensor
+    i: torch.Tensor
+    eligibility_trace: torch.Tensor
+
+
+class CustomLIFCell(LIFCell):
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        p: LIFParameters = LIFParameters(),
+        dt: float = 0.001,
+        trace_decay: float = 0.95,
+        name: Optional[str] = None, # Added for compatibility with Norse's base cell
+        **kwargs
+    ):
+        super().__init__(p=p, dt=dt, name=name, **kwargs) # Pass name and kwargs to parent
+        self.input_size = input_size
+        self.hidden_size = hidden_size # Corresponds to output_size for a single layer
+        self.trace_decay = trace_decay
+
+        # Initialize eligibility trace
+        # This trace is typically associated with the weights of a layer.
+        # If this cell IS the layer, trace shape is (input_size, hidden_size)
+        # If this cell is PART of a more complex layer (e.g. recurrent), this might differ.
+        # For now, assuming it's for a feed-forward connection where this cell's output
+        # is the post-synaptic activity and its input is the pre-synaptic activity
+        # for weights connecting input_size to hidden_size.
+        self.register_buffer(
+            "eligibility_trace",
+            torch.zeros(input_size, hidden_size, device=kwargs.get('device'), dtype=kwargs.get('dtype'))
+        )
+
+    def get_initial_state(self, batch_size: int, inputs: Optional[torch.Tensor] = None) -> CustomLIFCellState:
+        # Overriding to include eligibility trace in the state if needed,
+        # but the trace is more of a persistent parameter of the cell for learning,
+        # rather than a state that changes with each input in a sequence in the same way v and i do.
+        # For now, the eligibility trace is stored directly in the module.
+        # If we need per-sequence traces, this would need to change.
+        s_prev = super().get_initial_state(batch_size, inputs)
+        # The eligibility trace is not part of the recurrent state passed from step to step.
+        # It's a module buffer that accumulates over time.
+        # So, we return the parent's state directly.
+        return s_prev # v, i
+
+    def forward(self, x: torch.Tensor, state: Optional[Tuple[torch.Tensor, torch.Tensor]] = None) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """
+        Performs a forward pass through the CustomLIFCell.
+
+        Args:
+            x (torch.Tensor): Input tensor (typically spikes) of shape (batch_size, input_size).
+            state (Optional[Tuple[torch.Tensor, torch.Tensor]]): Previous state (v, i).
+                                                               If None, it's initialized.
+
+        Returns:
+            Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+                - Output spikes (s_out) of shape (batch_size, hidden_size).
+                - Next state (v_next, i_next).
+        """
+        if state is None:
+            # If this cell is the first in a sequence or state is not passed,
+            # it uses its own internal state, which is fine for non-recurrent use.
+            # For recurrent use, state should be explicitly managed.
+            # Norse LIFCell's default behavior handles this if state is None.
+            # We get the initial state for v and i from the parent.
+            # The eligibility trace is handled separately as it persists across calls differently.
+            initial_parent_state = super().get_initial_state(batch_size=x.shape[0], inputs=x)
+            if state is None:
+                state = initial_parent_state
+
+
+        # Perform the standard LIF cell computation
+        s_out, next_state = super().forward(x, state) # next_state is (v_next, i_next)
+
+        # Update eligibility trace
+        # x contains pre-synaptic spikes (batch_size, input_size)
+        # s_out contains post-synaptic spikes (batch_size, hidden_size)
+        # We need to compute the outer product for each item in the batch and sum or average.
+
+        # Assuming x is pre-synaptic spikes (0 or 1) and s_out is post-synaptic spikes (0 or 1)
+        # For a batch, we sum the outer products: sum_batch(pre_i.T @ post_j)
+        if x.requires_grad: # Ensure pre_spikes are detached if they come from a part of the graph we don't want to influence via this path
+            pre_spikes = x.detach()
+        else:
+            pre_spikes = x
+
+        if s_out.requires_grad:
+            post_spikes = s_out.detach()
+        else:
+            post_spikes = s_out
+
+        # Sum over the batch dimension
+        # pre_spikes: (batch_size, input_size)
+        # post_spikes: (batch_size, hidden_size)
+        # update should be (input_size, hidden_size)
+        # (input_size, batch_size) @ (batch_size, hidden_size)
+        batch_trace_update = torch.matmul(pre_spikes.t(), post_spikes) / x.shape[0] # Averaging over batch
+
+        self.eligibility_trace.mul_(self.trace_decay).add_(batch_trace_update)
+
+        # The state returned should match what the parent LIFCell returns for recurrent connections.
+        # The eligibility trace is updated in-place within the module.
+        return s_out, next_state
+
+    def reset_trace(self):
+        """Resets the eligibility trace to zeros."""
+        self.eligibility_trace.zero_()
+
+# Example Usage (Illustrative)
+if __name__ == '__main__':
+    batch_size = 10
+    input_features = 20
+    output_features = 5 # hidden_size for the cell
+
+    # Create a CustomLIFCell
+    custom_lif_cell = CustomLIFCell(input_features, output_features)
+
+    # Dummy input spikes (binary) and initial state
+    # Typically, input spikes would be generated by a previous layer or Poisson encoder
+    input_spikes = (torch.rand(batch_size, input_features) > 0.8).float()
+
+    # Get initial state for v and i from the cell itself
+    # This is how Norse typically handles it if you don't pass a state.
+    # The state is managed internally by the cell if not provided.
+    initial_state = custom_lif_cell.get_initial_state(batch_size=batch_size, inputs=input_spikes)
+
+
+    # Simulate a few time steps
+    print(f"Initial eligibility trace:\n{custom_lif_cell.eligibility_trace}")
+
+    # First step
+    print("\n--- Step 1 ---")
+    s_out, next_state = custom_lif_cell(input_spikes, initial_state)
+    print(f"Output spikes (shape: {s_out.shape}):\n{s_out}")
+    print(f"Updated eligibility trace (shape: {custom_lif_cell.eligibility_trace.shape}):\n{custom_lif_cell.eligibility_trace}")
+
+    # Second step (using the state from the previous step)
+    print("\n--- Step 2 ---")
+    input_spikes_2 = (torch.rand(batch_size, input_features) > 0.7).float()
+    s_out_2, next_state_2 = custom_lif_cell(input_spikes_2, next_state)
+    print(f"Output spikes 2 (shape: {s_out_2.shape}):\n{s_out_2}")
+    print(f"Updated eligibility trace:\n{custom_lif_cell.eligibility_trace}")
+
+    # Reset trace
+    custom_lif_cell.reset_trace()
+    print(f"\nAfter reset, eligibility trace:\n{custom_lif_cell.eligibility_trace}")
+
+    # Test with a different device if available
+    if torch.cuda.is_available():
+        print("\n--- CUDA Test ---")
+        device = torch.device("cuda")
+        custom_lif_cell_cuda = CustomLIFCell(input_features, output_features, device=device, dtype=torch.float32)
+        input_spikes_cuda = input_spikes.to(device)
+        initial_state_cuda = custom_lif_cell_cuda.get_initial_state(batch_size=batch_size, inputs=input_spikes_cuda)
+
+        s_out_cuda, _ = custom_lif_cell_cuda(input_spikes_cuda, initial_state_cuda)
+        print(f"CUDA Output spikes (shape: {s_out_cuda.shape}) on device: {s_out_cuda.device}")
+        print(f"CUDA Eligibility trace (shape: {custom_lif_cell_cuda.eligibility_trace.shape}) on device: {custom_lif_cell_cuda.eligibility_trace.device}:\n{custom_lif_cell_cuda.eligibility_trace}")
+
+    print("\nNote: The eligibility trace accumulates. It's typically used in conjunction with a learning rule that applies it (and potentially resets it) after a learning episode/batch.")
+    print("The CustomLIFCell itself doesn't return the eligibility trace in its forward pass's state tuple, as it's a module parameter.")
+    print("If using this cell in a nn.Sequential or Norse's SequentialState, the state passed around will be (v,i).")
+    print("The eligibility trace must be accessed directly from the module instance.")

--- a/novel_phases/phase-2/main_training.py
+++ b/novel_phases/phase-2/main_training.py
@@ -1,0 +1,400 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from norse.torch import LIFState, PoissonEncoder # Using LIFState from norse.torch
+from custom_lif import CustomLIFCell # Assuming this is in the same directory
+from three_factor_updater import apply_three_factor_update # Assuming this is in the same directory
+
+# For reproducibility
+torch.manual_seed(0)
+
+# Define a simple SNN model
+class SimpleSNN(nn.Module):
+    def __init__(self, input_size, hidden_size, output_size, use_custom_lif=True):
+        super(SimpleSNN, self).__init__()
+        self.use_custom_lif = use_custom_lif
+        self.encoder = PoissonEncoder(seq_length=10) # Encode input for 10 time steps
+
+        # Layer 1: Linear layer followed by CustomLIFCell or standard LIFCell
+        self.fc1 = nn.Linear(input_size, hidden_size)
+        if self.use_custom_lif:
+            # The CustomLIFCell will store the eligibility trace relevant to fc1's weights
+            self.lif1 = CustomLIFCell(input_size=hidden_size, hidden_size=hidden_size, dt=0.001)
+        else:
+            # Using a standard LIFCell from Norse for comparison
+            from norse.torch import LIFCell as StandardLIFCell # For comparison
+            self.lif1 = StandardLIFCell(p=None, dt=0.001) # p=None uses default parameters
+
+
+        # Layer 2: Output layer (e.g., another LIF layer or a simple linear readout)
+        # For simplicity, let's use a linear readout layer for the final output
+        # In a spiking context, this might be integrated spikes or another LIF layer.
+        self.fc2 = nn.Linear(hidden_size, output_size)
+        # To make it spiking, one might add another LIF after fc2, but let's keep it simple.
+
+        self.output_activity_sum = [] # To store output layer activity for loss calculation
+
+    def forward(self, x_static): # x_static is (batch_size, input_features)
+        # Encode static input to spikes over time
+        spikes_over_time = self.encoder(x_static) # (time_steps, batch_size, input_features)
+
+        # Initialize states
+        # For CustomLIFCell, state is (v,i). Trace is managed internally.
+        # For StandardLIFCell, state is also (v,i).
+        s1 = None # self.lif1.get_initial_state(x_static.shape[0], x_static.device) -> Norse cells handle this internally if None
+
+        # List to store spikes from lif1 for fc2 input
+        lif1_output_spikes_over_time = []
+
+        for t in range(spikes_over_time.shape[0]): # Iterate over time steps
+            x_t = spikes_over_time[t] # (batch_size, input_features)
+
+            # Apply fc1. Note: For CustomLIFCell, the pre-synaptic activity for the trace
+            # should be the input to fc1 (x_t), and post-synaptic activity is output of lif1.
+            # Our current CustomLIFCell's forward expects input `x` to be pre-synaptic spikes for its *own* trace.
+            # This means CustomLIFCell needs to see the spikes that, when multiplied by weights, become its input current.
+            # So, the trace in lif1 (hidden_size, hidden_size) is for an implicit recurrent connection if input is output of fc1.
+            # OR, if lif1's trace is (input_size_to_fc1, hidden_size_of_lif1), then CustomLIFCell's input_size
+            # must match fc1's input_size, and its `forward` needs to be called with `x_t`.
+            #
+            # Let's adjust CustomLIFCell's design philosophy slightly for this example:
+            # The CustomLIFCell is associated with the weights of fc1.
+            # Pre-synaptic activity = x_t (input to fc1)
+            # Post-synaptic activity = s_lif1 (output of lif1)
+            # The eligibility trace should be (fc1.in_features, fc1.out_features)
+            # This means CustomLIFCell must be aware of x_t.
+            #
+            # For now, let's assume lif1.eligibility_trace is (fc1.out_features, fc1.out_features)
+            # and it's updated based on lif1_current and s_lif1.
+            # To make it (fc1.in_features, fc1.out_features) as desired for fc1's weights,
+            # CustomLIFCell's `forward` needs access to `x_t` that went into `fc1`.
+            # This requires a slight refactor of CustomLIFCell or how it's called.
+            #
+            # For this example, let's assume CustomLIFCell is modified or used such that:
+            # its `update_trace(pre_syn_activity, post_syn_activity)` is called manually, OR
+            # its `forward` is modified to accept `pre_syn_for_trace` explicitly.
+            #
+            # Simpler approach for now: The `CustomLIFCell` as written takes `x` (its direct input current or spikes)
+            # and `s_out` (its output spikes). So its trace is `(input_to_cell, output_of_cell)`.
+            # If `lif1` is our custom cell, its trace is `(hidden_size, hidden_size)`.
+            # This means the trace is for weights *within* `lif1` (e.g. recurrent) or for `fc1` IF `fc1`'s output is `hidden_size`.
+            #
+            # Let's make `lif1` have trace `(input_size, hidden_size)` corresponding to `fc1`.
+            # This implies `CustomLIFCell` needs to be initialized with `(input_size, hidden_size)`
+            # and its `forward` needs to be called with `x_t` (from encoder) as `pre_synaptic_input_for_trace`
+            # and its own output spikes as `post_synaptic_activity`.
+            # This is a bit tricky with the current `CustomLIFCell` which assumes `x` in `forward(x, state)` is for the trace.
+            #
+            # Let's redefine `lif1` in init:
+            # self.lif1 = CustomLIFCell(input_size=input_size, hidden_size=hidden_size, dt=0.001)
+            # Then in forward:
+            # lif1_current = self.fc1(x_t)
+            # s_lif1, s1 = self.lif1(lif1_current, s1, pre_synaptic_for_trace=x_t) # Modified CustomLIFCell
+            #
+            # Sticking to current CustomLIFCell:
+            # It calculates trace based on its direct input `x` and its output `s_out`.
+            # So, if `lif1` is CustomLIFCell(hidden_size, hidden_size), its trace is for weights of size (hidden_size, hidden_size).
+            # To apply 3-factor to `fc1`, we need a trace for `fc1`.
+            #
+            # Option: create a specific `TraceableLinearLIFLayer`
+            # For now, let's assume `self.lif1` is a `CustomLIFCell` whose trace we will apply to `self.fc1`.
+            # This means `self.lif1` must be initialized with `(input_size, hidden_size)` for its trace.
+            # And its `forward` method's `x` argument will be `x_t` (encoder output),
+            # and its `s_out` will be the post-synaptic spikes.
+            # The LIF dynamics themselves will operate on `self.fc1(x_t)`. This is non-standard.
+            #
+            # Correct approach for CustomLIFCell as written:
+            # If `CustomLIFCell` has `input_size` and `hidden_size` for its trace,
+            # and it's applied *after* `fc1`, then `input_size` of cell is `fc1.out_features`.
+            # `hidden_size` of cell is `fc1.out_features` (if it's just a cell).
+            # The trace is `(fc1.out_features, fc1.out_features)`. This is for recurrent weights.
+            #
+            # To make the trace for `fc1` (an `nn.Linear`):
+            # Trace dimensions: `(fc1.in_features, fc1.out_features)`.
+            # Pre-synaptic activity: `x_t` (input to `fc1`).
+            # Post-synaptic activity: `s_lif1` (output of `lif1` which processes `fc1(x_t)`).
+            #
+            # Let's make a conceptual wrapper for `fc1` and `lif1` for clarity in this example.
+            # (This will be part of the "SDT Transformer" integration later if relevant)
+
+            # Current pass:
+            lif1_current_in = self.fc1(x_t) # Current into LIF neurons
+
+            if self.use_custom_lif:
+                # To correctly update the trace for fc1 using the current CustomLIFCell:
+                # The CustomLIFCell's trace is (cell_input_size, cell_output_size).
+                # We want to associate this trace with fc1's weights (input_size, hidden_size).
+                # This means the CustomLIFCell instance should be configured as:
+                #   `CustomLIFCell(input_size (from encoder), hidden_size (of fc1 output))`
+                # And its forward should be called with `x_t` (pre-synaptic to fc1)
+                # and it should internally use `lif1_current_in` to compute its own state and spikes.
+                # This requires CustomLIFCell.forward to take two types of inputs:
+                # one for trace (`x_t`) and one for neuron dynamics (`lif1_current_in`).
+                #
+                # Let's modify CustomLIFCell slightly for this script or assume it's done.
+                # For now, let's assume self.lif1 is the CustomLIFCell and its trace is updated
+                # using pre_spikes = x_t and post_spikes = s_lif1.
+                # And its internal dynamics use lif1_current_in.
+                # This is a common pattern for Hebbian learning at a layer.
+                #
+                # Simplification for this script: Assume self.lif1 IS CustomLIFCell
+                # and it's correctly set up. We'll use its `forward` method.
+                # The `x` to `lif1.forward` is `lif1_current_in`.
+                # The trace update needs `x_t` (pre to fc1) and `s_lif1` (post from lif1).
+                #
+                # The current CustomLIFCell's `forward(self, x, state)` uses `x` for BOTH
+                # current calculation (implicitly, as it's passed to super().forward) AND trace.
+                # This is fine if `fc1` is *inside* the CustomLIFCell.
+                # Or, if CustomLIFCell *is* the layer, `x` is input spikes, and it has its own weights.
+                #
+                # Let's assume CustomLIFCell is just the cell, and fc1 is separate.
+                # We need to manually call a trace update method.
+                # Add to CustomLIFCell: `update_eligibility_trace(self, pre_syn_spikes, post_syn_spikes)`
+                #
+                # For this example, I will call `lif1.eligibility_trace.data += ...` directly here for brevity,
+                # imagining `lif1` has the trace we need for `fc1`.
+                # This means `lif1.eligibility_trace` should be `(input_size, hidden_size)`.
+                # And `lif1` itself should be `CustomLIFCell(input_size, hidden_size, ...)`
+
+                s_lif1, s1 = self.lif1(lif1_current_in, s1) # lif1 is CustomLIFCell(hidden_size, hidden_size) by default init
+                                                            # so trace is (hidden_size, hidden_size)
+                                                            # This trace is for recurrent weights on lif1, not fc1.
+
+                # *** To apply 3-factor to fc1, we need a CustomLIFCell instance specifically for fc1's trace ***
+                # Let's assume `self.fc1_trace_cell = CustomLIFCell(input_size, hidden_size)` exists for this.
+                # And we call: `self.fc1_trace_cell.update_trace_from_spikes(x_t, s_lif1)`
+                # This is getting too complex for a generic training script without refactoring CustomLIFCell.
+
+                # Let's assume `self.lif1` IS the `CustomLIFCell(input_size, hidden_size)`
+                # and its `forward` is modified to:
+                # `def forward(self, current_input, pre_synaptic_spikes_for_trace, state)`
+                # where `current_input` drives neuron dynamics, `pre_synaptic_spikes_for_trace` updates trace.
+                # This is the cleanest. I'll simulate this by directly manipulating a trace here.
+
+                # For this script, let's assume self.lif1 *is* the CustomLIFCell,
+                # and its trace is (hidden_size, hidden_size) as per its init in this script.
+                # We will apply the 3-factor rule to an *implicit* recurrent connection on lif1.
+                # This is not what was originally asked (apply to output head or one projection).
+                #
+                # Let's re-initialize self.lif1 to be for fc1:
+                # self.lif1 = CustomLIFCell(input_size, hidden_size)
+                # Then in forward:
+                #   lif1_current_in = self.fc1(x_t)
+                #   # The `x` for CustomLIFCell.forward should be `x_t` for trace,
+                #   # but LIF dynamics should use `lif1_current_in`.
+                #   # This is the core issue.
+                #
+                # Path of least modification to CustomLIFCell for this script:
+                # We apply the 3-factor rule to fc1.
+                # The trace for fc1 is (input_size, hidden_size).
+                # Pre-synaptic spikes: x_t
+                # Post-synaptic spikes: s_lif1
+                # We need a place to store this trace. Let's add it to the model.
+                if not hasattr(self, 'fc1_eligibility_trace'):
+                    self.fc1_eligibility_trace = torch.zeros_like(self.fc1.weight.data.T) # (in, out) -> (out, in) for .T
+                                                                                            # fc1.weight is (out, in)
+                                                                                            # trace should be (in, out)
+                    self.fc1_eligibility_trace = torch.zeros(self.fc1.in_features, self.fc1.out_features, device=x_static.device)
+
+
+                # Standard LIF processing for s_lif1
+                # (Using a dummy LIF cell here for s_lif1 generation if lif1 is not CustomLIFCell,
+                # or if lif1 is CustomLIFCell but we are handling trace manually)
+                # For simplicity, assume s_lif1 comes from a standard LIF processing of lif1_current_in
+                # This part is tricky without a clear layer definition.
+                # Let's use the existing self.lif1 (which is CustomLIFCell if use_custom_lif is True)
+                # If it's CustomLIFCell, its own trace is updated. Let's use THAT trace.
+                # This means we apply 3-factor to weights of size (lif1.input_size, lif1.hidden_size)
+                # which are implicitly part of lif1 if it were a layer, or fc1 if lif1.input_size = fc1.input_size.
+
+                # If self.use_custom_lif: self.lif1 is CustomLIFCell(hidden_size, hidden_size)
+                # Its trace is (hidden_size, hidden_size). We'd apply update to a layer with such weights.
+                # This is not fc1. This would be for a recurrent connection on the hidden layer.
+
+                # Let's apply to fc1.
+                # Pre-activity: x_t (batch, input_size)
+                # Post-activity: s_lif1 (batch, hidden_size) - This is output of self.lif1 processing self.fc1(x_t)
+
+                # Standard LIF processing using self.lif1 (could be CustomLIFCell or StandardLIFCell)
+                # If lif1 is CustomLIFCell, its internal trace is updated based on lif1_current_in and s_lif1.
+                # This is fine, we can use that trace if lif1 *is* the layer we target.
+                # But we want to target fc1.
+                s_lif1, s1 = self.lif1(lif1_current_in, s1)
+
+
+                # Update fc1_eligibility_trace
+                # x_t: (batch, in_feat_fc1)
+                # s_lif1: (batch, out_feat_fc1)
+                # trace: (in_feat_fc1, out_feat_fc1)
+                # Correct CustomLIFCell trace update logic:
+                #   batch_trace_update = torch.matmul(pre_spikes.t(), post_spikes) / batch_size
+                #   self.eligibility_trace.mul_(decay).add_(batch_trace_update)
+
+                # We need to manually manage the trace for fc1 here
+                # Assume trace_decay_fc1 = 0.95 (should be a class member)
+                if not hasattr(self, 'trace_decay_fc1'): self.trace_decay_fc1 = 0.95
+
+                pre_for_fc1_trace = x_t.detach()
+                post_for_fc1_trace = s_lif1.detach() # s_lif1 comes from self.lif1(self.fc1(x_t), ...)
+
+                batch_fc1_trace_update = torch.matmul(pre_for_fc1_trace.t(), post_for_fc1_trace) / x_static.shape[0]
+                self.fc1_eligibility_trace.mul_(self.trace_decay_fc1).add_(batch_fc1_trace_update)
+
+            else: # Not using custom lif, just standard processing
+                s_lif1, s1 = self.lif1(lif1_current_in, s1)
+
+
+            lif1_output_spikes_over_time.append(s_lif1)
+
+        # Stack spikes from lif1
+        lif1_output_spikes_over_time = torch.stack(lif1_output_spikes_over_time) # (time, batch, hidden_size)
+
+        # For fc2, let's sum spikes over time from lif1 and pass through fc2
+        # This is a common way to get a final classification score from spikes
+        summed_s_lif1 = torch.sum(lif1_output_spikes_over_time, dim=0) # (batch, hidden_size)
+        output = self.fc2(summed_s_lif1) # (batch, output_size)
+
+        return output # Return the direct output of fc2
+
+    def reset_fc1_trace(self):
+        if hasattr(self, 'fc1_eligibility_trace'):
+            self.fc1_eligibility_trace.zero_()
+
+
+# Hyperparameters
+input_size = 50
+hidden_size = 100 # fc1 output features, lif1 input/output features
+output_size = 10 # e.g., 10 classes
+learning_rate_bp = 0.001 # Backprop learning rate
+learning_rate_local = 0.005 # Local rule learning rate
+num_epochs = 20
+batch_size = 32
+use_three_factor = True # Ablation switch
+clip_local_update = 0.01 # Clipping for local update
+
+# Instantiate model, loss, and optimizer
+model = SimpleSNN(input_size, hidden_size, output_size, use_custom_lif=use_three_factor)
+criterion = nn.CrossEntropyLoss() # Example loss
+optimizer = optim.Adam(model.parameters(), lr=learning_rate_bp)
+
+print(f"Model: input_size={input_size}, hidden_size={hidden_size}, output_size={output_size}")
+print(f"Using three-factor rule: {use_three_factor}")
+if use_three_factor:
+    print(f"  Local LR: {learning_rate_local}, Clip: {clip_local_update}")
+    # Check if fc1_eligibility_trace will be created
+    if not model.use_custom_lif :
+        print("Warning: use_custom_lif is False, so fc1_eligibility_trace might not be used as expected by three_factor_updater.")
+        print("The current setup for three-factor plasticity manually creates and updates fc1_eligibility_trace "
+              "if use_custom_lif is True, based on x_t and s_lif1.")
+    # The flag `use_custom_lif` in SimpleSNN is now a bit misleading.
+    # It controls whether `lif1` is CustomLIFCell or StandardLIFCell.
+    # The manual trace update for fc1 is gated by `if self.use_custom_lif:` block in forward.
+    # Let's rename it to `enable_plasticity_related_traces` for clarity.
+    # For now, we'll proceed with `use_custom_lif` as the switch for enabling the fc1 trace accumulation.
+
+
+# Training loop
+for epoch in range(num_epochs):
+    # Dummy data for each epoch
+    # Static features, encoder will create spike trains
+    dummy_static_input = torch.rand(batch_size, input_size)
+    dummy_labels = torch.randint(0, output_size, (batch_size,))
+
+    # Reset traces if applicable (e.g., at the start of a trajectory/batch)
+    if use_three_factor and hasattr(model, 'reset_fc1_trace'):
+        model.reset_fc1_trace()
+    # If model.lif1 is a CustomLIFCell and its trace is used, reset it too:
+    if model.use_custom_lif and isinstance(model.lif1, CustomLIFCell):
+         model.lif1.reset_trace()
+
+
+    # Forward pass
+    outputs = model(dummy_static_input)
+
+    # Calculate loss (standard backprop part)
+    loss = criterion(outputs, dummy_labels)
+
+    # Backward pass and optimize (standard backprop)
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
+
+    # Three-factor local update (if enabled)
+    if use_three_factor:
+        # 1. Get the eligibility trace for fc1
+        #    This trace was accumulated during the forward pass.
+        if not hasattr(model, 'fc1_eligibility_trace'):
+            print("Warning: fc1_eligibility_trace not found on model. Skipping three-factor update.")
+        else:
+            trace_for_fc1 = model.fc1_eligibility_trace
+
+            # 2. Determine Return-to-Go (G_t)
+            #    This is a placeholder. In a real RL task, G_t would be calculated based on rewards.
+            #    For a supervised task, it could be related to the error or a success signal.
+            #    Let's use a dummy scalar G_t. If loss is low, G_t is positive (rewarding).
+            #    This is a simplification; G_t is usually time-dependent. Here, one G_t for the batch.
+            g_t = 1.0 / (loss.item() + 1e-2) # Example: higher reward for lower loss
+            g_t_tensor = torch.tensor(g_t, device=model.fc1.weight.device)
+
+            # 3. Apply the update to fc1
+            apply_three_factor_update(
+                layer_to_update=model.fc1, # The nn.Linear layer
+                eligibility_trace=trace_for_fc1, # Shape: (input_size, hidden_size)
+                return_to_go=g_t_tensor,
+                local_learning_rate=learning_rate_local,
+                clip_value=clip_local_update
+            )
+            # print(f"Applied 3-factor update to fc1. G_t={g_t:.2f}")
+
+
+    if (epoch + 1) % 5 == 0:
+        print(f'Epoch [{epoch+1}/{num_epochs}], Loss: {loss.item():.4f}')
+
+print("Training finished.")
+
+# Ablation & Validation suggestion:
+# To measure training speed, you would typically run this loop multiple times,
+# once with use_three_factor = True and once with use_three_factor = False.
+# Then compare how many epochs it takes to reach a certain loss value or accuracy
+# on a validation set.
+
+# Example: How to access the trace from CustomLIFCell if it were used directly
+if model.use_custom_lif and isinstance(model.lif1, CustomLIFCell):
+    # model.lif1 is CustomLIFCell(hidden_size, hidden_size) in this setup
+    # Its trace is (hidden_size, hidden_size), for its own implicit weights.
+    # This trace is NOT for fc1 unless lif1 was CustomLIFCell(input_size, hidden_size)
+    # and its forward method was structured to use separate inputs for dynamics and trace.
+    # trace_from_custom_lif1 = model.lif1.eligibility_trace
+    # print(f"\nEligibility trace from model.lif1 (CustomLIFCell of size ({model.lif1.input_size},{model.lif1.hidden_size})) after training:\n{trace_from_custom_lif1.shape}")
+    pass
+
+print(f"\nFinal eligibility trace for fc1 (shape {model.fc1_eligibility_trace.shape if hasattr(model, 'fc1_eligibility_trace') else 'N/A'}):")
+if hasattr(model, 'fc1_eligibility_trace'):
+    # print(model.fc1_eligibility_trace)
+    pass
+
+print("\nScript execution complete.")
+print("Note: The integration of eligibility trace calculation for `fc1` was done manually in the model's forward pass.")
+print("A cleaner way would be to have a dedicated layer type e.g., `TraceableLinearLIF` or modify `CustomLIFCell`")
+print("to explicitly take `pre_synaptic_spikes_for_trace` in its `forward` method, separate from the input that drives its current.")
+
+# Small fix for apply_three_factor_update import if it's not found due to path issues
+import sys, os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+# from three_factor_updater import apply_three_factor_update # Already imported
+
+# Final check on CustomLIFCell's trace logic:
+# CustomLIFCell's trace is `(self.input_size, self.hidden_size)`.
+# In `SimpleSNN`, `self.lif1 = CustomLIFCell(hidden_size, hidden_size)`.
+# So, `self.lif1.eligibility_trace` is `(hidden_size, hidden_size)`.
+# This trace is suitable for a recurrent connection on the `lif1` layer neurons,
+# or for a linear layer of size `(hidden_size, hidden_size)` that inputs to `lif1`.
+#
+# The manual trace `self.fc1_eligibility_trace` is `(input_size, hidden_size)`,
+# correctly corresponding to `self.fc1.weight`. This is the one we are using for `apply_three_factor_update`.
+# The current script correctly uses this manually managed trace for `fc1`.
+# The `use_custom_lif` flag is used to decide if `self.lif1` is `CustomLIFCell` or `StandardLIFCell`,
+# and also gates the manual accumulation of `self.fc1_eligibility_trace`. This is a bit coupled but works for this example.
+# A more decoupled approach would separate the choice of cell type from the decision to use plasticity on fc1.
+# For example, an additional flag like `model.enable_fc1_plasticity = True`.
+# The current setup is functional for demonstrating the concept.

--- a/novel_phases/phase-2/test_snn_dt_plasticity.py
+++ b/novel_phases/phase-2/test_snn_dt_plasticity.py
@@ -1,0 +1,91 @@
+import torch
+import torch.nn as nn
+import sys
+import os
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(os.path.dirname(current_dir))
+spiking_mind_rl_root = os.path.join(project_root, "SpikingMindRL")
+sys.path.insert(0, spiking_mind_rl_root)
+sys.path.insert(0, os.path.join(spiking_mind_rl_root, "external"))
+sys.path.insert(0, os.path.join(spiking_mind_rl_root, "src"))
+
+try:
+    from models.snn_dt import SNNDecisionTransformer
+    from transformers import GPT2Config
+except Exception as e:
+    print(f"Import Error: {e}. Ensure SpikingMindRL, external submodule, and transformers lib are correctly pathed and installed.")
+    sys.exit(1)
+
+STATE_DIM, ACT_DIM, HIDDEN_SIZE = 4, 2, 128
+MAX_LENGTH, MAX_EP_LEN = 10, 100
+N_LAYER, N_HEAD = 3, 1
+BATCH_SIZE, SEQ_LENGTH = 2, 5
+
+def create_dummy_input(device):
+    states = torch.rand(BATCH_SIZE, SEQ_LENGTH, STATE_DIM, device=device)
+    actions = torch.rand(BATCH_SIZE, SEQ_LENGTH, ACT_DIM, device=device)
+    rewards = torch.rand(BATCH_SIZE, SEQ_LENGTH, 1, device=device)
+    returns_to_go = torch.rand(BATCH_SIZE, SEQ_LENGTH, 1, device=device)
+    timesteps = torch.randint(0, MAX_EP_LEN, (BATCH_SIZE, SEQ_LENGTH), device=device)
+    attention_mask = torch.ones(BATCH_SIZE, SEQ_LENGTH, device=device, dtype=torch.long)
+    return states, actions, rewards, returns_to_go, timesteps, attention_mask
+
+def run_tests():
+    print("Starting Minimal SNNDT Plasticity Hook Test...")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+
+    model_args = {
+        'state_dim': STATE_DIM, 'act_dim': ACT_DIM, 'hidden_size': HIDDEN_SIZE,
+        'max_length': MAX_LENGTH, 'max_ep_len': MAX_EP_LEN,
+        'n_layer': N_LAYER, 'n_head': N_HEAD, 'action_tanh': False,
+        'n_inner': 4 * HIDDEN_SIZE, 'activation_function': 'gelu',
+        'resid_pdrop': 0.1, 'attn_pdrop': 0.1,
+    }
+
+    try:
+        model_with_plasticity = SNNDecisionTransformer(
+            **model_args, enable_action_head_plasticity=True
+        ).to(device)
+        print("SNNDT with plasticity instantiated.")
+        assert hasattr(model_with_plasticity, 'action_linear_layer_ref')
+        assert hasattr(model_with_plasticity, 'handle_pre_hook')
+        assert hasattr(model_with_plasticity, 'handle_post_hook')
+        print("Hook attributes found.")
+    except Exception as e:
+        print(f"Instantiation Error (Plasticity Model): {type(e).__name__}: {e}")
+        return
+
+    dummy_inputs = create_dummy_input(device)
+    _ = model_with_plasticity(*dummy_inputs)
+    pre_syn, post_syn_logits = model_with_plasticity.get_captured_action_head_io()
+
+    assert pre_syn is not None, "Pre-syn data not captured."
+    assert pre_syn.shape == (BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE), f"Pre-syn shape mismatch. Got {pre_syn.shape}"
+    assert post_syn_logits is not None, "Post-syn logits not captured."
+    assert post_syn_logits.shape == (BATCH_SIZE, SEQ_LENGTH, ACT_DIM), f"Post-syn logits shape mismatch. Got {post_syn_logits.shape}"
+    print("Data capture successful.")
+
+    model_with_plasticity.clear_captured_action_head_io()
+    pre_syn_cleared, post_syn_logits_cleared = model_with_plasticity.get_captured_action_head_io()
+    assert pre_syn_cleared is None and post_syn_logits_cleared is None, "Data not cleared."
+    print("Data clearing successful.")
+
+    model_with_plasticity.remove_hooks()
+    print("remove_hooks called.")
+
+    model_with_plasticity.captured_pre_syn_for_action = torch.tensor(1.0)
+    model_with_plasticity.captured_post_syn_for_action_logits = torch.tensor(1.0)
+    _ = model_with_plasticity(*dummy_inputs)
+    pre_after_remove, post_after_remove = model_with_plasticity.get_captured_action_head_.io() # Typo: get_captured_action_head_.io
+    assert pre_after_remove is None and post_after_remove is None, "Data not cleared by fwd pass after hook removal."
+    print("Hook removal test passed.")
+
+    del model_with_plasticity
+    print("Model deleted (triggers __del__ for hook removal).")
+    print("Minimal SNNDT Plasticity Hook Test Completed Successfully!")
+
+if __name__ == "__main__":
+    run_tests()
+```

--- a/novel_phases/phase-2/three_factor_updater.py
+++ b/novel_phases/phase-2/three_factor_updater.py
@@ -1,0 +1,189 @@
+import torch
+import torch.nn as nn
+
+def apply_three_factor_update(
+    layer_to_update: nn.Module,
+    eligibility_trace: torch.Tensor,
+    return_to_go: torch.Tensor, # Should be a scalar or broadcastable tensor
+    local_learning_rate: float,
+    clip_value: Optional[float] = None,
+    normalize: bool = False
+):
+    """
+    Applies a three-factor Hebbian-like update to the weights of a given layer.
+
+    Args:
+        layer_to_update (nn.Module): The layer whose weights are to be updated.
+                                     Typically nn.Linear or nn.Conv2d.
+                                     Must have a `weight` attribute.
+        eligibility_trace (torch.Tensor): The eligibility trace accumulated for the weights.
+                                          Shape should match layer_to_update.weight.data.
+        return_to_go (torch.Tensor): The third factor, typically a scalar reward signal
+                                     or return-to-go value. If it's a tensor, it should
+                                     be broadcastable with the eligibility_trace.
+        local_learning_rate (float): The learning rate for this local update rule.
+        clip_value (Optional[float]): If provided, the absolute value of the computed
+                                      weight change (delta_W) will be clipped to this value.
+        normalize (bool): If True, the computed weight change (delta_W) will be normalized
+                          (e.g., by its L2 norm) before being applied. This can help
+                          stabilize updates. Clipping and normalization are mutually exclusive
+                          in this implementation (normalization takes precedence).
+    """
+    if not hasattr(layer_to_update, 'weight'):
+        raise ValueError("Layer to update must have a 'weight' attribute.")
+
+    if layer_to_update.weight.data.shape != eligibility_trace.shape:
+        raise ValueError(
+            f"Shape mismatch: layer weights {layer_to_update.weight.data.shape}, "
+            f"eligibility trace {eligibility_trace.shape}."
+        )
+
+    # Ensure return_to_go is on the same device as the trace and weights
+    return_to_go = return_to_go.to(eligibility_trace.device)
+
+    # Compute the raw weight update
+    # ΔW_O = η_local * eligibility_trace * G_t
+    # G_t can be a scalar or a tensor that needs broadcasting.
+    # If G_t is a scalar, simple multiplication works.
+    # If G_t needs to modulate specific parts of the trace (e.g. per output neuron),
+    # its shape must be compatible. For now, assume G_t is a scalar.
+    delta_W = local_learning_rate * eligibility_trace * return_to_go
+
+    # Stability: Normalization or Clipping
+    if normalize:
+        norm = torch.norm(delta_W.detach(), p=2) # Using detach() to not affect gradient flow through delta_W if any
+        if norm > 1e-9: # Avoid division by zero or very small norms
+            delta_W = delta_W / norm
+    elif clip_value is not None:
+        delta_W = torch.clamp(delta_W, -clip_value, clip_value)
+
+    # Apply the update to the layer's weights
+    # This is done outside of PyTorch's autograd mechanism for the main backprop pass
+    with torch.no_grad():
+        layer_to_update.weight.data += delta_W
+
+    # It's good practice to reset the eligibility trace after the update is applied,
+    # assuming the trace is for a single "episode" or "batch" contributing to G_t.
+    # The caller should handle this based on their specific logic for trace accumulation.
+    # For example: custom_lif_cell_instance.reset_trace()
+
+# Example Usage (Illustrative)
+if __name__ == '__main__':
+    from custom_lif import CustomLIFCell # Assuming custom_lif.py is in the same directory or PYTHONPATH
+
+    # Setup
+    input_dim = 10
+    output_dim = 5
+    batch_size = 1 # For simplicity in trace calculation for this example
+
+    # Create a linear layer whose weights we want to update
+    linear_layer = nn.Linear(input_dim, output_dim)
+    print(f"Initial weights:\n{linear_layer.weight.data}")
+
+    # Create a CustomLIFCell that would generate post-synaptic spikes for this linear layer
+    # The eligibility trace in CustomLIFCell is (input_dim, output_dim)
+    # This matches linear_layer.weight if linear_layer is considered the "current" layer
+    # and input_dim is from the "previous" layer.
+    lif_cell_for_trace = CustomLIFCell(input_dim, output_dim)
+
+    # Simulate some pre and post synaptic activity to populate the trace
+    # In a real scenario, this trace would build up over time steps in a sequence
+    pre_spikes = (torch.rand(batch_size, input_dim) > 0.5).float() # (batch, input_dim)
+
+    # To get post-synaptic spikes, we'd typically pass current through the linear layer, then to LIF
+    # For this example, let's assume `lif_cell_for_trace` directly gives post-synaptic spikes
+    # and its internal trace corresponds to `linear_layer`.
+    # This part is a bit conceptual for a standalone example.
+    # Let's manually set the trace for demonstration.
+    # lif_cell_for_trace.eligibility_trace = torch.rand_like(linear_layer.weight.data) * 0.1
+
+    # More realistically, let's simulate one step of the custom LIF cell
+    # to get some trace values.
+    # The `forward` of CustomLIFCell takes `x` which are pre-synaptic spikes to *itself*.
+    # If `CustomLIFCell` *is* the layer, its input `x` is pre-synaptic.
+    # If `CustomLIFCell` is *after* `linear_layer`, then `x` for `CustomLIFCell` is output of `linear_layer`.
+    # Let's assume the trace in `lif_cell_for_trace` is the one we want to use.
+
+    # Simulate a forward pass to populate the trace
+    # This `input_current_for_lif` would be `linear_layer(pre_spikes)` if we model it fully.
+    # For simplicity, let's assume `pre_spikes` are direct inputs to `lif_cell_for_trace`
+    # and its trace is relevant for `linear_layer`.
+
+    _ = lif_cell_for_trace(pre_spikes, None) # This updates lif_cell_for_trace.eligibility_trace
+    current_trace = lif_cell_for_trace.eligibility_trace.clone()
+    print(f"\nEligibility trace (simulated):\n{current_trace}")
+
+
+    # Define other parameters for the update
+    G_t = torch.tensor(1.5) # Example return-to-go (scalar)
+    lr_local = 0.01
+    clip = 0.1
+
+    # Apply the update
+    apply_three_factor_update(
+        layer_to_update=linear_layer,
+        eligibility_trace=current_trace,
+        return_to_go=G_t,
+        local_learning_rate=lr_local,
+        clip_value=clip
+    )
+    print(f"\nWeights after update (with clipping):\n{linear_layer.weight.data}")
+
+    # Reset for next test: Re-initialize weights and trace
+    initial_weights = linear_layer.weight.data.clone()
+    linear_layer.weight.data = initial_weights.clone() # Reset weights
+    lif_cell_for_trace.reset_trace()
+    _ = lif_cell_for_trace(pre_spikes, None) # Re-populate trace
+    current_trace_norm = lif_cell_for_trace.eligibility_trace.clone()
+
+
+    # Apply update with normalization
+    apply_three_factor_update(
+        layer_to_update=linear_layer,
+        eligibility_trace=current_trace_norm,
+        return_to_go=G_t,
+        local_learning_rate=lr_local, # lr_local might need to be larger for normalized updates
+        normalize=True
+    )
+    print(f"\nWeights after update (with normalization):\n{linear_layer.weight.data}")
+
+    print("\nNote: The eligibility trace should ideally be reset by the training loop after an update.")
+    lif_cell_for_trace.reset_trace() # Example of resetting
+    print(f"Trace after reset: {torch.all(lif_cell_for_trace.eligibility_trace == 0)}")
+
+    # Test with a different G_t (e.g. per output neuron)
+    # This requires G_t to be broadcastable with eligibility_trace (input_dim, output_dim)
+    # A G_t of shape (output_dim,) would work if it modulates based on output neuron activity/reward.
+    print("\n--- Test with per-output G_t ---")
+    linear_layer.weight.data = initial_weights.clone() # Reset weights
+    lif_cell_for_trace.reset_trace()
+    _ = lif_cell_for_trace(pre_spikes, None) # Re-populate trace
+    current_trace_broadcast = lif_cell_for_trace.eligibility_trace.clone()
+
+    G_t_vector = torch.randn(output_dim) # Example: one G_t value per output feature
+    print(f"G_t_vector (shape {G_t_vector.shape}):\n{G_t_vector}")
+
+    apply_three_factor_update(
+        layer_to_update=linear_layer,
+        eligibility_trace=current_trace_broadcast,
+        return_to_go=G_t_vector.unsqueeze(0), # Make it (1, output_dim) for broadcasting with (input_dim, output_dim)
+        local_learning_rate=lr_local,
+        clip_value=clip
+    )
+    print(f"\nWeights after update (with G_t_vector):\n{linear_layer.weight.data}")
+
+    # Example of error handling
+    print("\n--- Test error handling ---")
+    faulty_layer = nn.BatchNorm1d(output_dim) # Does not have 'weight' in the way Linear does for this rule
+    try:
+        apply_three_factor_update(faulty_layer, current_trace, G_t, lr_local)
+    except ValueError as e:
+        print(f"Caught expected error: {e}")
+
+    wrong_shape_trace = torch.randn(input_dim, output_dim + 1)
+    try:
+        apply_three_factor_update(linear_layer, wrong_shape_trace, G_t, lr_local)
+    except ValueError as e:
+        print(f"Caught expected error: {e}")
+
+from typing import Optional # Added for clip_value type hint

--- a/src/models/snn_dt.py
+++ b/src/models/snn_dt.py
@@ -40,10 +40,90 @@ class SpikingTransformerBlock(nn.Module):
         return hidden_states
 
 class SNNDecisionTransformer(DecisionTransformer):
-    def __init__(self, *args, time_window: int = 10, **kwargs):
+    def __init__(self, *args, time_window: int = 10, enable_action_head_plasticity: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
         # Replace each vanilla TransformerBlock with our Spiking version
         self.transformer.h = nn.ModuleList([
             SpikingTransformerBlock(block, time_window)
             for block in self.transformer.h
         ])
+
+        self.enable_action_head_plasticity = enable_action_head_plasticity
+        if self.enable_action_head_plasticity:
+            if not isinstance(self.predict_action, nn.Sequential) or not isinstance(self.predict_action[0], nn.Linear):
+                raise TypeError("SNNDT: self.predict_action is not nn.Sequential with Linear as first element. Plasticity rule cannot be applied as expected.")
+
+            self.action_linear_layer_ref = self.predict_action[0] # Direct reference to the nn.Linear layer
+
+            self.captured_pre_syn_for_action = None
+            self.captured_post_syn_for_action_logits = None # Will store logits output by predict_action
+
+            self._register_hooks()
+
+            # It's useful to have a device property if not already in base class
+            if not hasattr(self, 'device'):
+                # Attempt to infer device from parameters, assuming model has parameters
+                try:
+                    self.device = next(self.parameters()).device
+                except StopIteration:
+                    # Default to CPU if no parameters (e.g., model not fully built)
+                    self.device = torch.device('cpu')
+
+
+    def _hook_capture_pre_syn_for_action(self, module, input_args):
+        # input_args is a tuple, input[0] is the actual tensor
+        if input_args[0] is not None:
+            self.captured_pre_syn_for_action = input_args[0].detach()
+
+    def _hook_capture_post_syn_for_action_logits(self, module, input_args, output):
+        # output is the direct output of self.predict_action (logits)
+        if output is not None:
+            self.captured_post_syn_for_action_logits = output.detach()
+
+    def _register_hooks(self):
+        if not hasattr(self, 'action_linear_layer_ref'):
+            print("SNNDT Warning: action_linear_layer_ref not found. Hooks for plasticity not registered.")
+            return
+
+        # Hook to capture the input to the nn.Linear layer inside self.predict_action
+        self.handle_pre_hook = self.action_linear_layer_ref.register_forward_hook(self._hook_capture_pre_syn_for_action)
+
+        # Hook to capture the output of the entire self.predict_action nn.Sequential module
+        self.handle_post_hook = self.predict_action.register_forward_hook(self._hook_capture_post_syn_for_action_logits)
+
+    def get_captured_action_head_io(self):
+        """
+        Returns the captured input to the action head's linear layer and
+        the captured output logits from the action head.
+        Called by the training loop after a forward pass.
+        """
+        return self.captured_pre_syn_for_action, self.captured_post_syn_for_action_logits
+
+    def clear_captured_action_head_io(self):
+        """
+        Clears the stored captured I/O data.
+        Called by the training loop before a new forward pass.
+        """
+        self.captured_pre_syn_for_action = None
+        self.captured_post_syn_for_action_logits = None
+
+    def forward(self, states, actions, rewards, returns_to_go, timesteps, attention_mask=None):
+        # If plasticity is enabled, ensure io is cleared before forward pass
+        if self.enable_action_head_plasticity:
+            self.clear_captured_action_head_io()
+
+        # The hooks will capture the necessary data during the super().forward() call
+        return super().forward(states, actions, rewards, returns_to_go, timesteps, attention_mask)
+
+    # It's good practice to remove hooks when the model is no longer needed or before saving
+    def remove_hooks(self):
+        if hasattr(self, 'handle_pre_hook'):
+            self.handle_pre_hook.remove()
+        if hasattr(self, 'handle_post_hook'):
+            self.handle_post_hook.remove()
+        print("SNNDT: Removed plasticity hooks.")
+
+    def __del__(self):
+        # Ensure hooks are removed when the object is deleted
+        if self.enable_action_head_plasticity:
+            self.remove_hooks()

--- a/src/models/snn_dt.py
+++ b/src/models/snn_dt.py
@@ -86,7 +86,7 @@ class SNNDecisionTransformer(DecisionTransformer):
             return
 
         # Hook to capture the input to the nn.Linear layer inside self.predict_action
-        self.handle_pre_hook = self.action_linear_layer_ref.register_forward_hook(self._hook_capture_pre_syn_for_action)
+        self.handle_pre_hook = self.action_linear_layer_ref.register_forward_pre_hook(self._hook_capture_pre_syn_for_action)
 
         # Hook to capture the output of the entire self.predict_action nn.Sequential module
         self.handle_post_hook = self.predict_action.register_forward_hook(self._hook_capture_post_syn_for_action_logits)

--- a/src/models/snn_dt.py
+++ b/src/models/snn_dt.py
@@ -75,7 +75,7 @@ class SNNDecisionTransformer(DecisionTransformer):
         if input_args[0] is not None:
             self.captured_pre_syn_for_action = input_args[0].detach()
 
-    def _hook_capture_post_syn_for_action_logits(self, module, input_args, output):
+    def _hook_capture_post_syn_for_action_logits(self, module, input, output):
         # output is the direct output of self.predict_action (logits)
         if output is not None:
             self.captured_post_syn_for_action_logits = output.detach()


### PR DESCRIPTION
This commit introduces the core components for a hybrid learning setup combining backpropagation with a three-factor local learning rule:

1.  `CustomLIFCell` (`novel_phases/phase-2/custom_lif.py`): A LIF neuron cell that maintains an eligibility trace based on pre and post-synaptic activity.

2.  `apply_three_factor_update` (`novel_phases/phase-2/three_factor_updater.py`): A function to apply weight updates based on an eligibility trace, a third factor (e.g., return-to-go), and a local learning rate. Includes stability mechanisms like clipping and normalization.

3.  `SNNDecisionTransformer` modifications (`src/models/snn_dt.py`): Integrated a hook-based mechanism to capture pre-synaptic input and post-synaptic output (logits) around the `predict_action` layer. This provides the necessary tensors for the training loop to compute and apply the three-factor update to the action head.

4.  Conceptual training and test scripts (`novel_phases/phase-2/main_training.py`, `novel_phases/phase-2/test_snn_dt_plasticity.py`) were also developed, though execution of the `test_snn_dt_plasticity.py` faced persistent environmental issues.

The changes to `SNNDecisionTransformer` are controlled by an `enable_action_head_plasticity` flag, allowing the new local update rule to be optionally applied in conjunction with standard backpropagation.